### PR TITLE
Adding Navigator.waitForPendingNavigations() to enable some level of chaining

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,13 +6,3 @@ let _uid = 0;
 export function uid() {
   return _uid++;
 }
-
-let _lock = false;
-export const lock = {
-  acquire() {
-    return _lock ? false : (_lock = true);
-  },
-  release() {
-    _lock = false;
-  }
-};

--- a/tests/lock.test.js
+++ b/tests/lock.test.js
@@ -122,3 +122,23 @@ describe("locks during transition", () => {
     );
   });
 });
+
+describe("allows waiting on lock via waitForPendingNavigations", () => {
+  afterEach(() => {
+    clean();
+  });
+
+  test("present + replace", () => {
+    let { navigator, toJSON } = render({ initialState: [[{ screen: "Foo" }]] });
+
+    const nav = navigator();
+    nav.present({ screen: "Bar" });
+    nav
+      .waitForPendingNavigations()
+      .then(() => nav.replace({ screen: "Spam" }, { animated: false }));
+
+    jest.runAllTimers();
+
+    expect(toJSON()).toEqual(["Foo", "Spam"]);
+  });
+});


### PR DESCRIPTION
At Geekie, we have one particular use case in which one screen may "redirect" to another screen (via navigator.replace). Sometimes, this redirect happens as soon as the first screen mounts, and in this case there is a race condition: the call to replace() may happen before the lock is released, causing the redirect to be silently ignored.

This commit exposes a waitForPendingNavigations() API that allows navigator clients to await for the current transition to finish prior to issuing new navigation commands. This is insufficient to implement a true queueing mechanism, but then there seems to be no currently use cases that would require a true queueing system.

Test Plan:

- Used over Geekie to fix a bug in the HighlightOpener screen
- Ran `npx jest`
- Ran `npx eslint` over all *.js files